### PR TITLE
Fix: Filament v2.13 $records wrong type

### DIFF
--- a/src/Actions/ExportAction.php
+++ b/src/Actions/ExportAction.php
@@ -41,7 +41,7 @@ class ExportAction extends BulkAction implements FromCollection, WithCustomChunk
 
     protected ?string $model;
 
-    protected ?Collection $records;
+    protected Collection | Closure | null $records;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
`$records` type changed to `Collection | Closure | null`. Required to work with Filament v2.13.