### PR TITLE
Fix: Declaration of ExportBulkAction::make(string  = 'export'): static must be compatible with BaseAction::make(?string $name = null): static

### DIFF
--- a/src/Actions/Pages/ExportAction.php
+++ b/src/Actions/Pages/ExportAction.php
@@ -12,7 +12,7 @@ class ExportAction extends Action
         ExportableAction::setUp as parentSetUp;
     }
 
-    public static function make(string $name = 'export'): static
+    public static function make(?string $name = 'export'): static
     {
         return parent::make($name);
     }

--- a/src/Actions/Tables/ExportAction.php
+++ b/src/Actions/Tables/ExportAction.php
@@ -12,7 +12,7 @@ class ExportAction extends Action
         ExportableAction::setUp as parentSetUp;
     }
 
-    public static function make(string $name = 'export'): static
+    public static function make(?string $name = 'export'): static
     {
         return parent::make($name);
     }

--- a/src/Actions/Tables/ExportBulkAction.php
+++ b/src/Actions/Tables/ExportBulkAction.php
@@ -12,7 +12,7 @@ class ExportBulkAction extends BulkAction
         ExportableAction::setUp as parentSetUp;
     }
 
-    public static function make(string $name = 'export'): static
+    public static function make(?string $name = 'export'): static
     {
         return parent::make($name);
     }


### PR DESCRIPTION
**Declaration of pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction::make(string $name = 'export'): static must be compatible with Filament\Support\Actions\BaseAction::make(?string $name = null): static**

Fix: #20 