### PR TITLE
Better table query default. Support for `counts()`, `exists()`, and aggregates like `avg()`

### DIFF
--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -24,6 +24,8 @@ trait WithColumns
 
     protected ?Collection $cachedMap = null;
 
+    protected ?string $columnsSource = null;
+
     public function withColumns(Closure | array | string | null $columns = null): self
     {
         if (is_callable($columns)) {
@@ -54,12 +56,16 @@ trait WithColumns
     {
         $this->generatedColumns = fn () => ($this->cachedMap ??= $this->createFieldMappingFromTable())->toArray();
 
+        $this->columnsSource = 'table';
+
         return $this;
     }
 
     public function fromForm(): static
     {
         $this->generatedColumns = fn () => ($this->cachedMap ??= $this->createFieldMappingFromForm())->toArray();
+
+        $this->columnsSource = 'form';
 
         return $this;
     }
@@ -79,6 +85,8 @@ trait WithColumns
                 )
                 ->toArray();
         };
+
+        $this->columnsSource = 'model';
 
         return $this;
     }

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -197,13 +197,11 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function query(): Builder
     {
-        if ($this->columnsSource === 'table') {
-            $baseQuery = invade($this->livewire)->getTableQuery();
-        } else {
-            $baseQuery = $this->getModelClass()::query();
-        }
+        $query = $this->columnsSource === 'table'
+            ? invade($this->livewire)->getFilteredTableQuery()
+            : $this->getModelClass()::query();
 
-        return $baseQuery
+        return $query
             ->when(
                 $this->recordIds,
                 fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -31,6 +31,7 @@ use pxlrbt\FilamentExcel\Exports\Concerns\WithWidths;
 use pxlrbt\FilamentExcel\Exports\Concerns\WithWriterType;
 use pxlrbt\FilamentExcel\Interactions\AskForFilename;
 use pxlrbt\FilamentExcel\Interactions\AskForWriterType;
+use function Livewire\invade;
 
 class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize, WithColumnWidths, WithColumnFormatting, WithCustomChunkSize
 {
@@ -196,7 +197,7 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function query(): Builder
     {
-        return $this->getModelClass()::query()
+        return invade($this->livewire)->getTableQuery()
             ->when(
                 $this->recordIds,
                 fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -197,7 +197,13 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function query(): Builder
     {
-        return invade($this->livewire)->getTableQuery()
+        if ($this->columnsSource === 'table') {
+            $baseQuery = invade($this->livewire)->getTableQuery();
+        } else {
+            $baseQuery = $this->getModelClass()::query();
+        }
+
+        return $baseQuery
             ->when(
                 $this->recordIds,
                 fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)


### PR DESCRIPTION
Now it uses the customised `TableQuery` instead of getting a generic query from the model, and respects aggregate columns, sorts, etc.

Further suggestion: Currently, it doesn't automatically add aggregate columns if you have `counts` or other aggregate methods on table columns but they're not defined in `getTableQuery`. We can tackle this in column related PRs.