### PR TITLE
Support tables `->getStateUsing()` and `->formatStateUsing()`

### DIFF
--- a/src/Columns/Column.php
+++ b/src/Columns/Column.php
@@ -4,6 +4,7 @@ namespace pxlrbt\FilamentExcel\Columns;
 
 use Closure;
 use Filament\Support\Concerns\EvaluatesClosures;
+use Filament\Tables\Columns\Column as TableColumn;
 use Illuminate\Support\Str;
 use Laravel\SerializableClosure\SerializableClosure;
 
@@ -19,7 +20,11 @@ class Column
 
     public Closure | string | null $format = null;
 
-    public SerializableClosure $formatStateUsing;
+    public ?TableColumn $tableColumn = null;
+
+    public ?SerializableClosure $getStateUsing = null;
+
+    public ?SerializableClosure $formatStateUsing = null;
 
     protected function __construct($name)
     {
@@ -76,9 +81,23 @@ class Column
         return $this;
     }
 
+    public function tableColumn(TableColumn $tableColumn): static
+    {
+        $this->tableColumn = $tableColumn;
+
+        return $this;
+    }
+
     public function getFormat()
     {
         return $this->format;
+    }
+
+    public function getStateUsing(callable $callback): static
+    {
+        $this->getStateUsing = new SerializableClosure($callback);
+
+        return $this;
     }
 
     public function formatStateUsing(callable $callback): static

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -136,7 +136,9 @@ trait WithColumns
 
         return $columns->mapWithKeys(
             fn (Tables\Columns\Column $column) => [
-                $column->getName() => Column::make($column->getName())->heading($column->getLabel()),
+                $column->getName() => Column::make($column->getName())
+                    ->heading($column->getLabel())
+                    ->formatStateUsing(invade($column)->formatStateUsing ?? fn ($state) => $state),
             ]
         );
     }

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -120,9 +120,10 @@ trait WithColumns
 
         return $extracted
             ->filter(fn ($field) => $field instanceof Field)
-            ->mapWithKeys(
-                fn (Field $field) => [$field->getName() => Column::make($field->getName())->heading($field->getLabel())]
-            );
+            ->mapWithKeys(fn (Field $field) => [
+                $field->getName() => Column::make($field->getName())
+                    ->heading($field->getLabel()),
+            ]);
     }
 
     protected function createFieldMappingFromTable(): Collection
@@ -134,12 +135,12 @@ trait WithColumns
             $columns = collect($table->getColumns());
         }
 
-        return $columns->mapWithKeys(
-            fn (Tables\Columns\Column $column) => [
-                $column->getName() => Column::make($column->getName())
-                    ->heading($column->getLabel())
-                    ->formatStateUsing(invade($column)->formatStateUsing ?? fn ($state) => $state),
-            ]
-        );
+        return $columns->mapWithKeys(fn (Tables\Columns\Column $column) => [
+            $column->getName() => Column::make($column->getName())
+                ->heading($column->getLabel())
+                ->tableColumn($column)
+                ->getStateUsing(invade($column)->getStateUsing)
+                ->formatStateUsing(invade($column)->formatStateUsing),
+        ]);
     }
 }

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -24,6 +24,8 @@ trait WithColumns
 
     protected ?Collection $cachedMap = null;
 
+    protected ?string $columnsSource = null;
+
     public function withColumns(Closure | array | string | null $columns = null): self
     {
         if (is_callable($columns)) {
@@ -54,12 +56,16 @@ trait WithColumns
     {
         $this->generatedColumns = fn () => ($this->cachedMap ??= $this->createFieldMappingFromTable())->toArray();
 
+        $this->columnsSource = 'table';
+
         return $this;
     }
 
     public function fromForm(): static
     {
         $this->generatedColumns = fn () => ($this->cachedMap ??= $this->createFieldMappingFromForm())->toArray();
+
+        $this->columnsSource = 'form';
 
         return $this;
     }
@@ -79,6 +85,8 @@ trait WithColumns
                 )
                 ->toArray();
         };
+
+        $this->columnsSource = 'model';
 
         return $this;
     }

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -11,9 +11,7 @@ use Filament\Tables;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Collection;
-
 use function Livewire\invade;
-
 use pxlrbt\FilamentExcel\Columns\Column;
 
 trait WithColumns

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -31,6 +31,7 @@ use pxlrbt\FilamentExcel\Exports\Concerns\WithWidths;
 use pxlrbt\FilamentExcel\Exports\Concerns\WithWriterType;
 use pxlrbt\FilamentExcel\Interactions\AskForFilename;
 use pxlrbt\FilamentExcel\Interactions\AskForWriterType;
+use function Livewire\invade;
 
 class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize, WithColumnWidths, WithColumnFormatting, WithCustomChunkSize
 {
@@ -196,7 +197,7 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function query(): Builder
     {
-        return $this->getModelClass()::query()
+        return invade($this->livewire)->getTableQuery()
             ->when(
                 $this->recordIds,
                 fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Livewire\Component;
+use function Livewire\invade;
 use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
@@ -31,7 +32,6 @@ use pxlrbt\FilamentExcel\Exports\Concerns\WithWidths;
 use pxlrbt\FilamentExcel\Exports\Concerns\WithWriterType;
 use pxlrbt\FilamentExcel\Interactions\AskForFilename;
 use pxlrbt\FilamentExcel\Interactions\AskForWriterType;
-use function Livewire\invade;
 
 class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize, WithColumnWidths, WithColumnFormatting, WithCustomChunkSize
 {

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -197,7 +197,13 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function query(): Builder
     {
-        return invade($this->livewire)->getTableQuery()
+        if ($this->columnsSource === 'table') {
+            $baseQuery = invade($this->livewire)->getTableQuery();
+        } else {
+            $baseQuery = $this->getModelClass()::query();
+        }
+
+        return $baseQuery
             ->when(
                 $this->recordIds,
                 fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)


### PR DESCRIPTION
This checks if there's a `formatStateUsing` defined on the filament table column and uses it, otherwise falls back on the default closure.

I'm not entirely sure how filament differentiates `getStateUsing` and `formatStateUsing`, but I believe they're not two different things in this package. If they were I would have implemented `getStateUsing` as well.

Let me know if I should make any changes.