### PR TITLE
Fix export when using a string as a key instead of an integer

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -257,10 +257,15 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
             $query = $this->modifyQueryUsing->getClosure()($query);
         }
 
+        $whereCondition = "whereIntegerInRaw";
+        if ($this->getModelInstance()->getKeyType() === 'string') {
+            $whereCondition = "whereIn";
+        }
+        
         return $this->query = $query
             ->when(
                 $this->recordIds,
-                fn ($query) => $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)
+                fn ($query) => $query->$whereCondition($this->modelKeyName, $this->recordIds)
             );
     }
 

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -248,6 +248,7 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
         }
 
         $livewire = $this->getLivewire();
+        $model = $this->getModelInstance();
 
         $query = $this->columnsSource === 'table'
             ? invade($livewire)->getFilteredTableQuery()
@@ -257,15 +258,12 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
             $query = $this->modifyQueryUsing->getClosure()($query);
         }
 
-        $whereCondition = "whereIntegerInRaw";
-        if ($this->getModelInstance()->getKeyType() === 'string') {
-            $whereCondition = "whereIn";
-        }
-        
         return $this->query = $query
             ->when(
                 $this->recordIds,
-                fn ($query) => $query->$whereCondition($this->modelKeyName, $this->recordIds)
+                fn ($query) => $model->getKeyType() === 'string'
+                    ? $query->whereIn($this->modelKeyName, $this->recordIds)
+                    : $query->whereIntegerInRaw($this->modelKeyName, $this->recordIds)
             );
     }
 


### PR DESCRIPTION
When rows are selected, they are ignored on export when the model key type is a string. Because of the `whereIntegerInRaw`.