### PR TITLE
Serialize queries when queueing, to allow for table based queries to be carried through to queued export

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^8.0",
         "filament/filament": "^2.0",
-        "maatwebsite/excel": "^3.1"
+        "maatwebsite/excel": "^3.1",
+        "anourvalar/eloquent-serialize": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exports/Concerns/CanQueue.php
+++ b/src/Exports/Concerns/CanQueue.php
@@ -2,6 +2,8 @@
 
 namespace pxlrbt\FilamentExcel\Exports\Concerns;
 
+use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
+
 trait CanQueue
 {
     protected bool $isQueued = false;
@@ -43,5 +45,6 @@ trait CanQueue
         }
 
         $this->livewire = null;
+        $this->query = EloquentSerializeFacade::serialize($this->query());
     }
 }

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -2,6 +2,7 @@
 
 namespace pxlrbt\FilamentExcel\Exports;
 
+use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Concerns\EvaluatesClosures;
@@ -234,7 +235,6 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
         $query = $this->getQuery();
 
         if ($this->isQueued()) {
-            $this->query = null;
             $this->livewire = null;
         }
 
@@ -243,6 +243,10 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
 
     public function getQuery()
     {
+        if (is_string($this->query)) {
+            return EloquentSerializeFacade::unserialize($this->query);
+        }
+
         if ($this->query) {
             return $this->query;
         }


### PR DESCRIPTION
This allows for an export derived from the table as source using fromTable to pass it's query to the queue.