### PR TITLE
Set notification ID to create a notification once

### DIFF
--- a/src/FilamentExcelServiceProvider.php
+++ b/src/FilamentExcelServiceProvider.php
@@ -58,7 +58,7 @@ class FilamentExcelServiceProvider extends ServiceProvider
                 ['path' => $export['filename']]
             );
 
-            Notification::make('filament-excel:exports:' . $export['filename'] )
+            Notification::make('filament-excel:exports:' . md5($export['filename']))
                 ->title(__('filament-excel::notifications.download_ready.title'))
                 ->body(__('filament-excel::notifications.download_ready.body'))
                 ->success()

--- a/src/FilamentExcelServiceProvider.php
+++ b/src/FilamentExcelServiceProvider.php
@@ -58,7 +58,7 @@ class FilamentExcelServiceProvider extends ServiceProvider
                 ['path' => $export['filename']]
             );
 
-            Notification::make()
+            Notification::make('filament-excel:exports:' . $export['filename'] )
                 ->title(__('filament-excel::notifications.download_ready.title'))
                 ->body(__('filament-excel::notifications.download_ready.body'))
                 ->success()


### PR DESCRIPTION
Setting the ID of the notifications allows to set this notification as unique, preventing to create more than a notification for the same exported file