### PR TITLE
Fix: Spanish translation typo

### DIFF
--- a/lang/es/notifications.php
+++ b/lang/es/notifications.php
@@ -3,7 +3,7 @@
 return [
     'queued' => [
         'title' => 'Exportación en curso',
-        'body' => 'La exporación está en curso. Serás notificado cuando esté disponble para su descarga.',
+        'body' => 'La exportación está en curso. Serás notificado cuando esté disponble para su descarga.',
     ],
 
     'download_ready' => [


### PR DESCRIPTION
The `body` of the `queued` notification says **_exporación_** instead of **_exportación_**