### PR TITLE
Use qualified primary key name to support relation managers with `fromTable()`

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -189,8 +189,8 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
     public function hydrate($livewire = null, $records = null, $formData = null): static
     {
         $this->livewire = $livewire;
-        $this->modelKeyName = $this->getModelInstance()->getKeyName();
-        $this->recordIds = $records?->pluck($this->modelKeyName)->toArray() ?? [];
+        $this->modelKeyName = $this->getModelInstance()->getQualifiedKeyName();
+        $this->recordIds = $records?->pluck(Str::afterLast($this->modelKeyName, '.'))->toArray() ?? [];
 
         $this->formData = $formData;
 

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -190,7 +190,7 @@ class ExcelExport implements HasMapping, HasHeadings, FromQuery, ShouldAutoSize,
     {
         $this->livewire = $livewire;
         $this->modelKeyName = $this->getModelInstance()->getQualifiedKeyName();
-        $this->recordIds = $records?->pluck(Str::afterLast($this->modelKeyName, '.'))->toArray() ?? [];
+        $this->recordIds = $records?->pluck($this->getModelInstance()->getKeyName())->toArray() ?? [];
 
         $this->formData = $formData;
 


### PR DESCRIPTION
Otherwise the key name is ambiguous in the `whereIn()` query clause.

Supporting relation managers with `fromTable()` ensures that pivot data works, as the table query is used to fetch records instead of the plain model class.