### PR TITLE
feature: add compatibility for filament V3 [finished]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "filament/filament": "^2.13.24|^3.0",
+        "php": "^8.1",
+        "filament/filament": "^3.0-stable",
         "maatwebsite/excel": "^3.1",
         "anourvalar/eloquent-serialize": "^1.2"
     },
@@ -39,5 +39,6 @@
     },
     "scripts": {
         "pint": "vendor/bin/pint"
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/src/Actions/Concerns/ExportableAction.php
+++ b/src/Actions/Concerns/ExportableAction.php
@@ -20,7 +20,7 @@ trait ExportableAction
         $this->modalWidth('md');
 
         $this->label(__('filament-excel::actions.label'));
-        $this->icon('heroicon-o-download');
+        $this->icon('heroicon-o-arrow-down-tray');
         $this->action(Closure::fromCallable([$this, 'handleExport']));
 
         $this->exports = collect([ExcelExport::make('export')->fromTable()]);

--- a/src/Actions/Pages/ExportAction.php
+++ b/src/Actions/Pages/ExportAction.php
@@ -22,7 +22,7 @@ class ExportAction extends Action
         $this->parentSetUp();
 
         $this->button();
-        $this->icon('heroicon-o-download');
+        $this->icon('heroicon-o-arrow-down-tray');
 
         $this->exports = collect([
             ExcelExport::make()->fromForm(),

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -129,7 +129,7 @@ trait WithColumns
         $livewire = $this->getLivewire();
 
         if ($livewire instanceof HasTable) {
-            $columns = collect(invade($this->getLivewire())->getTableColumns());
+            $columns = collect(invade($this->getLivewire())->getTable()->getColumns());
         } else {
             $table = $this->getResourceClass()::table(new Table());
             $columns = collect($table->getColumns());

--- a/src/FilamentExcelServiceProvider.php
+++ b/src/FilamentExcelServiceProvider.php
@@ -68,7 +68,7 @@ class FilamentExcelServiceProvider extends ServiceProvider
                 ->title(__('filament-excel::notifications.download_ready.title'))
                 ->body(__('filament-excel::notifications.download_ready.body'))
                 ->success()
-                ->icon('heroicon-o-download')
+                ->icon('heroicon-o-arrow-down-tray')
                 ->actions([
                     Action::make('download')
                         ->label(__('filament-excel::notifications.download_ready.download'))


### PR DESCRIPTION
- change deprecated icons
- support for filament V3
- support for php 8.1
- change the way getting columns as getTableColumns() is deprecated

need to use
 public static function hasToggleableTableColumns(): bool 
inside the listModel