### PR TITLE
Fix for using ->fromTable() & ->withColumns()

### DIFF
--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -45,6 +45,10 @@ trait WithColumns
         $columns = $this->evaluate($this->generatedColumns);
 
         foreach ($this->evaluate($this->columns) as $column) {
+            if($this->columnsSource === 'table') {
+                $column->tableColumn = $columns[$column->getName()]->tableColumn;
+            }
+
             $columns[$column->getName()] = $column;
         }
 


### PR DESCRIPTION
Merges the tableColumn property from the generated table column into the manually specified column. 