### PR TITLE
Added $livewire to modifyQueryUsing closure

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -261,7 +261,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
             : $this->getModelClass()::query();
 
         if ($this->modifyQueryUsing) {
-            $query = $this->modifyQueryUsing->getClosure()($query);
+            $query = $this->modifyQueryUsing->getClosure()($query, $livewire);
         }
 
         return $this->query = $query


### PR DESCRIPTION
Add `$livewire` to `modifyQueryUsing` closure allows users to get all properties of current livewire page, like `$ownerRecord`, which is useful to filter table records when using `withColumns()`.

Example:

```php
ExportAction::make()
     ->exports([
         ExcelExport::make()
            ->withColumns([
                Column::make('event.title')->heading(__('Evento')),
                Column::make('id')->heading(__('Registro')),
                Column::make('registration_date')->heading(__('Fecha de registro')),
                Column::make('applicant.full_name')->heading(__('Nombre')),
                Column::make('applicant.dni')->heading(__('DNI')),
            ])
            ->modifyQueryUsing(fn ($query, $livewire) => $query->where('event_id', $livewire->ownerRecord))
    ])
```