### PR TITLE
Inject $livewire and $tableQuery to modifyQueryUsing

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -261,7 +261,11 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
             : $this->getModelClass()::query();
 
         if ($this->modifyQueryUsing) {
-            $query = $this->modifyQueryUsing->getClosure()($query);
+            $query = app()->call($this->modifyQueryUsing->getClosure(), [
+                'query' => $query,
+                'livewire' => $livewire,
+                'tableQuery' => is_callable([invade($livewire), 'getFilteredTableQuery']) ? invade($livewire)->getFilteredTableQuery() : null
+            ]);
         }
 
         return $this->query = $query

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -264,7 +264,6 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
             $query = app()->call($this->modifyQueryUsing->getClosure(), [
                 'query' => $query,
                 'livewire' => $livewire,
-                'tableQuery' => is_callable([invade($livewire), 'getFilteredTableQuery']) ? invade($livewire)->getFilteredTableQuery() : null
             ]);
         }
 


### PR DESCRIPTION
Injecting those properties allow users to:

- `$livewire`: Allows users to access current Page. Example:

```php
ExportAction::make()
     ->exports([
         ExcelExport::make()
            ->withColumns([
                Column::make('event.title')->heading(__('Evento')),
                Column::make('id')->heading(__('Registro')),
                Column::make('registration_date')->heading(__('Fecha de registro')),
                Column::make('applicant.full_name')->heading(__('Nombre')),
                Column::make('applicant.dni')->heading(__('DNI')),
            ])
            ->modifyQueryUsing(fn ($query, $livewire) => $query->where('event_id', $livewire->ownerRecord))
    ])
```

- `$tableQuery`: Accessing filtered table query allows users to get the filtered records without using `forTable()` which could be useful to export custom columns. Example:

```php
ExportAction::make()
     ->exports([
         ExcelExport::make()
            ->withColumns([
                Column::make('event.title')->heading(__('Evento')),
                Column::make('id')->heading(__('Registro')),
                Column::make('registration_date')->heading(__('Fecha de registro')),
                Column::make('applicant.full_name')->heading(__('Nombre')),
                Column::make('applicant.dni')->heading(__('DNI')),
            ])
            ->modifyQueryUsing(fn ($query, $tableQuery) => $tableQuery ?? $query)
    ])
```