### PR TITLE
fix page class null on relationManager exports

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -138,6 +138,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
         $this->livewire = app($this->livewireClass);
 
         if ($this->livewire instanceof RelationManager) {
+            $this->livewire->pageClass = $this->livewireClass;
             $this->livewire->ownerRecord = $this->livewireOwnerRecord;
         }
 


### PR DESCRIPTION
Fix for problem we discussed on Discord

`Filament\Resources\RelationManagers\RelationManager::getPageClass(): Return value must be of type string, null returned`