### PR TITLE
Adding new interaction with a confirmation message

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,18 @@ ExportAction::make()->exports([
 ])
 ```
 
+You can also ask the user to confirm before starting the export:
+
+```php
+use pxlrbt\FilamentExcel\Actions\Tables\ExportAction;
+use pxlrbt\FilamentExcel\Exports\ExcelExport;
+
+ExportAction::make()->exports([
+    ExcelExport::make()
+        ->askForConfirmation('Confirm Export?', 'This may take a while. Please do not start multiple exports at the same time.')
+])
+```
+
 ### Modify the query
 
 You can modify the query that is used to retrieve the model by using `->modifyQueryUsing()`:

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -34,6 +34,7 @@ use pxlrbt\FilamentExcel\Exports\Concerns\WithWidths;
 use pxlrbt\FilamentExcel\Exports\Concerns\WithWriterType;
 use pxlrbt\FilamentExcel\Interactions\AskForFilename;
 use pxlrbt\FilamentExcel\Interactions\AskForWriterType;
+use pxlrbt\FilamentExcel\Interactions\AskForConfirmation;
 
 use function Livewire\invade;
 
@@ -41,6 +42,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
 {
     use AskForFilename;
     use AskForWriterType;
+    use AskForConfirmation;
     use CanIgnoreFormatting;
     use CanModifyQuery;
     use CanQueue, Exportable  {

--- a/src/Interactions/AskForConfirmation.php
+++ b/src/Interactions/AskForConfirmation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace pxlrbt\FilamentExcel\Interactions;
+
+use Filament\Forms\Components\Checkbox;
+
+trait AskForConfirmation
+{
+    public function askForConfirmation(string $label = null, string $helperText = null, callable $callback = null): self
+    {
+        $field = Checkbox::make('confirm')
+            ->label($label ?? __('Confirm'))
+            ->helperText($helperText ?? 'Please confirm that you want to export all records.')
+            ->required();
+
+        if (is_callable($callback)) {
+            $callback($field);
+        }
+
+        $this->formSchema[] = $field;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
My support team keeps mashing the export button and its an expensive query. I added a confirmation message so I could put the help text in there to ask them not to click it so often and thought other people might enjoy it.


<img width="489" alt="image" src="https://github.com/pxlrbt/filament-excel/assets/60545233/8cbfc621-6ad8-4960-8686-538f905dfd72">
