### PR TITLE
Honor table sort when exporting

### DIFF
--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -264,7 +264,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
         $model = $this->getModelInstance();
 
         $query = $this->useTableQuery
-            ? invade($livewire)->getFilteredSortedTableQuery()
+            ? $livewire->getFilteredSortedTableQuery()
             : $this->getModelClass()::query();
 
         if ($this->modifyQueryUsing) {

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -264,7 +264,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
         $model = $this->getModelInstance();
 
         $query = $this->useTableQuery
-            ? invade($livewire)->getFilteredTableQuery()
+            ? invade($livewire)->getFilteredSortedTableQuery()
             : $this->getModelClass()::query();
 
         if ($this->modifyQueryUsing) {


### PR DESCRIPTION
This enables the export to be sorted the same way the current table is.