### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -268,7 +268,7 @@ use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 
 ExportAction::make()->exports([
     ExcelExport::make()->withColumns([
-        Column::make('currency')->format(NumberFormat::FORMAT_CURRENCY_EUR_SIMPLE)
+        Column::make('currency')->format(NumberFormat::FORMAT_CURRENCY_EUR_INTEGER)
     ]),
 ])
 ```


### PR DESCRIPTION
hello,
small change in readme.
"FORMAT_CURRENCY_EUR_SIMPLE"  is deprecated:
1.28 use FORMAT_CURRENCY_EUR_INTEGER instead.

Source: https://github.com/PHPOffice/PhpSpreadsheet/commit/816b91d0b4a0c7285a9e3fc88c58f7730d922044