### PR TITLE
Fix: Remove the notification after the user clicks the download button when using database notifications

### DIFF
--- a/src/FilamentExcelServiceProvider.php
+++ b/src/FilamentExcelServiceProvider.php
@@ -76,7 +76,8 @@ class FilamentExcelServiceProvider extends PackageServiceProvider
                         Action::make('download')
                             ->label(__('filament-excel::notifications.download_ready.download'))
                             ->url($url, shouldOpenInNewTab: true)
-                            ->button(),
+                            ->button()
+                            ->close(),                            
                     ])
                     ->sendToDatabase(auth()->user());
             } else {


### PR DESCRIPTION
Fixed issue #174