### PR TITLE
security: use signed middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,17 @@
 <?php
 
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
+
 Route::get('filament-excel/{path}', function (string $path) {
+    $path = Storage::disk('filament-excel')->path($path);
+    $filename = substr($path, 37);
+
     return
         response()
-            ->download(Storage::disk('filament-excel')->path($path), substr($path, 37))
+            ->download($path, $filename)
             ->deleteFileAfterSend();
 })
+    ->middleware(['web', 'signed'])
     ->where('path', '.*')
     ->name('filament-excel-download');

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -138,7 +138,7 @@ trait WithColumns
         if ($livewire instanceof HasTable) {
             $columns = collect($livewire->getTable()->getColumns());
         } else {
-            $table = $this->getResourceClass()::table(new Table());
+            $table = $this->getResourceClass()::table(new Table);
             $columns = collect($table->getColumns());
         }
 


### PR DESCRIPTION
fix: use signed URL

The current version might allow a path traversal attack with badly configured webservers through the route for the export file download, because the route was using `{path}` and `->where('path', '.*')`.

Thanks to Kevin Pohl for making me aware of this issue.