### PR TITLE
Fix typo causing dynamic property deprecation warning in Concerns\WithColumnFormats

### DIFF
--- a/src/Exports/Concerns/WithColumnFormats.php
+++ b/src/Exports/Concerns/WithColumnFormats.php
@@ -16,7 +16,7 @@ trait WithColumnFormats
 
     public function getColumnFormats(): array
     {
-        return $this->columnFormat ??= $this->getMapping($this->getModelInstance())
+        return $this->columnFormats ??= $this->getMapping($this->getModelInstance())
             ->values()
             ->mapWithKeys(fn (Column $column, $key) => [
                 Coordinate::stringFromColumnIndex($key + 1) => $this->evaluate($column->getFormat()),


### PR DESCRIPTION
Hi 👋 

Currently dealing with deprecation warnings for a project I'm working on, and traced one back to this library.

```
Creation of dynamic property pxlrbt\FilamentExcel\Exports\ExcelExport::$columnFormat is deprecated in /var/www/vendor/pxlrbt/filament-excel/src/Exports/Concerns/WithColumnFormats.php on line 19
```

Looking at the code, I assume `$columnFormat` was a typo as the `$columnFormats` property already exists in the class.
This PR fixes that typo, when then removes the deprecation warning. 

I think technically this is a breaking change, as anything relying on `$columnFormat` being set won't work anymore.

Thanks for your work on this library! 
