### PR TITLE
Feature: Allow customization of download URL

### DIFF
--- a/config/filament-excel.php
+++ b/config/filament-excel.php
@@ -1,0 +1,7 @@
+<?php
+
+use pxlrbt\FilamentExcel\FilamentExcelUrlGenerator;
+
+return [
+    'url_generator_class' => FilamentExcelUrlGenerator::class,
+];

--- a/readme.md
+++ b/readme.md
@@ -415,18 +415,37 @@ class CustomExport extends ExcelExport
 
 By default, the package generates a signed URL with a default expiration time of 24 hours. The URL contains the filename and extension. Some WAF (Web Application Firewall) solutions can block the URL due to the fact that it links to a file, which contains parameters and can cause a false positive.
 
-If you need to customize the URL that's generated after the export has finished, you can do so like this:
+If you need to customize the URL that's generated after the export has finished, you can do by creating a class that implements the `GeneratesUrl` interface. For example:
 
 ```php
-use pxlrbt\FilamentExcel\FilamentExcelServiceProvider;
+namespace App\Actions;
 
-FilamentExcelServiceProvider::generateUrlUsing(function (array $export) {
-    return URL::temporarySignedRoute(
-        'filament-excel-download',
-        now()->addHours(2),
-        ['path' => $export['filename']]
-    );
-});
+use Illuminate\Support\Facades\URL;
+use pxlrbt\FilamentExcel\Interfaces\GeneratesUrl;
+
+class MyFilamentExcelUrlGenerator implements GeneratesUrl
+{
+    public function generateUrl(array $export): string
+    {
+        return URL::temporarySignedRoute(
+            'my-custom-route',
+            now()->addHours(2),
+            ['path' => $export['filename']]
+        );
+    }
+}
+```
+
+Publish the config file and update the `url_generator_class` key file to reflect that:
+
+```php
+php artisan vendor:publish --tag=filament-excel-config
+```
+
+```php
+return [
+    'url_generator_class' => App\Actions\MyFilamentExcelUrlGenerator::class,
+];
 ```
 
 When the notifications are sent out, the URL to the file be generated using your closure. The closure will receive the `$export` (array).

--- a/readme.md
+++ b/readme.md
@@ -411,6 +411,26 @@ class CustomExport extends ExcelExport
 }
 ```
 
+## Customize filename URL
+
+By default, the package generates a signed URL with a default expiration time of 24 hours. The URL contains the filename and extension. Some WAF (Web Application Firewall) solutions can block the URL due to the fact that it links to a file, which contains parameters and can cause a false positive.
+
+If you need to customize the URL that's generated after the export has finished, you can do so like this:
+
+```php
+use pxlrbt\FilamentExcel\FilamentExcelServiceProvider;
+
+FilamentExcelServiceProvider::generateUrlUsing(function (array $export) {
+    return URL::temporarySignedRoute(
+        'filament-excel-download',
+        now()->addHours(2),
+        ['path' => $export['filename']]
+    );
+});
+```
+
+When the notifications are sent out, the URL to the file be generated using your closure. The closure will receive the `$export` (array).
+
 ## Contributing
 
 If you want to contribute to this packages, you may want to test it in a real Filament project:

--- a/src/FilamentExcelUrlGenerator.php
+++ b/src/FilamentExcelUrlGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace pxlrbt\FilamentExcel;
+
+use Illuminate\Support\Facades\URL;
+use pxlrbt\FilamentExcel\Interfaces\GeneratesUrl;
+
+class FilamentExcelUrlGenerator implements GeneratesUrl
+{
+    public function generateUrl(array $export): string
+    {
+        return URL::temporarySignedRoute(
+            'filament-excel-download',
+            now()->addHours(24),
+            ['path' => $export['filename']]
+        );
+    }
+}

--- a/src/Interfaces/GeneratesUrl.php
+++ b/src/Interfaces/GeneratesUrl.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace pxlrbt\FilamentExcel\Interfaces;
+
+interface GeneratesUrl
+{
+    public function generateUrl(array $export): string;
+}


### PR DESCRIPTION
Hello @pxlrbt 

As i was encountering an edge case where my URLs were being filtered/transformed/blocked by CloudFlare due to the fact that the URL contains an extension (and parameters afterwards), i need the means to be able to build the URL on my own end.

This PR introduces the possibility to change how the final URL is generated.

It simplifies this but introducing a new default class that generates the URL but allows the possibility to swap this class using an interface and a config key.

The PR also updates the README to reflect that.

This is 100% fully backwards compatible and it should not introduce any breaking changes.

The default generator uses the same functionality.