### PR TITLE
Feature: Allow customization of URL generation (alternative)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -411,6 +411,28 @@ class CustomExport extends ExcelExport
 }
 ```
 
+## File download URL customization
+
+By default, the package generates a signed URL with a default expiration time of 24 hours. 
+The URL contains the filename including the extension. Some WAF (Web Application Firewall) solutions can block the URL due to the fact that it links to a file, which contains parameters and can cause a false positive.
+
+```php
+// Somewhere in a ServiceProvider in the `boot()` method.
+use pxlrbt\FilamentExcel\FilamentExport;
+
+FilamentExport::createExportUrlUsing(function ($export) {
+    $fileInfo = pathinfo($export['filename']);
+    $filenameWithoutExtension = $fileInfo['filename'];
+    $extension = $fileInfo['extension'];
+
+    return URL::temporarySignedRoute(
+        'your-custom-route',
+        now()->addHours(2),
+        ['path' => $filenameWithoutExtension, 'extension' => $extension]
+    );
+});
+```
+
 ## Contributing
 
 If you want to contribute to this packages, you may want to test it in a real Filament project:

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -62,11 +62,11 @@ class FilamentExport
         }
 
         foreach ($exports as $export) {
-            $url = $this->createUrl($export);
-
             if (! Storage::disk('filament-excel')->exists($export['filename'])) {
                 continue;
             }
+
+            $url = $this->createUrl($export);
 
             if (Filament::getCurrentPanel()->hasDatabaseNotifications()) {
                 $this->sendDatabaseNotification($export, $url);
@@ -83,14 +83,14 @@ class FilamentExport
 
     protected function createUrl(array $export): string
     {
-        if (is_null(static::$createExportUrlUsing)) {
-            return URL::temporarySignedRoute(
-                'filament-excel-download',
-                now()->addHours(24),
-                ['path' => $export['filename']]
-            );
+        if (static::$createExportUrlUsing !== null) {
+            return (static::$createExportUrlUsing)($export);
         }
 
-        return call_user_func(static::$createExportUrlUsing, $export);
+        return URL::temporarySignedRoute(
+            'filament-excel-download',
+            now()->addHours(24),
+            ['path' => $export['filename']]
+        );
     }
 }

--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace pxlrbt\FilamentExcel;
+
+use Closure;
+use Filament\Facades\Filament;
+use Filament\Notifications\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
+class FilamentExport
+{
+    public static ?Closure $createExportUrlUsing = null;
+
+    public static function createExportUrlUsing(Closure $closure): void
+    {
+        static::$createExportUrlUsing = $closure;
+    }
+
+    protected function sendDatabaseNotification(array $export, string $url): void
+    {
+        Notification::make(data_get($export, 'id'))
+            ->title(__('filament-excel::notifications.download_ready.title'))
+            ->body(__('filament-excel::notifications.download_ready.body'))
+            ->success()
+            ->icon('heroicon-o-arrow-down-tray')
+            ->actions([
+                Action::make('download')
+                    ->label(__('filament-excel::notifications.download_ready.download'))
+                    ->url($url, shouldOpenInNewTab: true)
+                    ->button()
+                    ->close(),
+            ])
+            ->sendToDatabase(auth()->user());
+    }
+
+    protected function sendPersistentNotification(array $export, string $url): void
+    {
+        Notification::make(data_get($export, 'id'))
+            ->title(__('filament-excel::notifications.download_ready.title'))
+            ->body(__('filament-excel::notifications.download_ready.body'))
+            ->success()
+            ->icon('heroicon-o-arrow-down-tray')
+            ->actions([
+                Action::make('download')
+                    ->label(__('filament-excel::notifications.download_ready.download'))
+                    ->url($url, shouldOpenInNewTab: true)
+                    ->button()
+                    ->close(),
+            ])
+            ->persistent()
+            ->send();
+    }
+
+    public function sendNotification(): void
+    {
+        $exports = cache()->pull(static::getNotificationCacheKey(auth()->id()));
+
+        if (! filled($exports)) {
+            return;
+        }
+
+        foreach ($exports as $export) {
+            $url = $this->createUrl($export);
+
+            if (! Storage::disk('filament-excel')->exists($export['filename'])) {
+                continue;
+            }
+
+            if (Filament::getCurrentPanel()->hasDatabaseNotifications()) {
+                $this->sendDatabaseNotification($export, $url);
+            } else {
+                $this->sendPersistentNotification($export, $url);
+            }
+        }
+    }
+
+    public static function getNotificationCacheKey($userId): string
+    {
+        return 'filament-excel:exports:'.$userId;
+    }
+
+    protected function createUrl(array $export): string
+    {
+        if (is_null(static::$createExportUrlUsing)) {
+            return URL::temporarySignedRoute(
+                'filament-excel-download',
+                now()->addHours(24),
+                ['path' => $export['filename']]
+            );
+        }
+
+        return call_user_func(static::$createExportUrlUsing, $export);
+    }
+}


### PR DESCRIPTION
Hello @pxlrbt 

After the discussion in #212 i went ahead and came up with an alternative solution.

Now you can configure the URL generation like this in a `boot()` method in a ServiceProvider.

```php
use pxlrbt\FilamentExcel\FilamentExport;

FilamentExport::createExportUrlUsing(function ($export) {
    $fileInfo = pathinfo($export['filename']);
    $filenameWithoutExtension = $fileInfo['filename'];
    $extension = $fileInfo['extension'];

    return URL::temporarySignedRoute(
        'your-custom-route',
        now()->addHours(2),
        ['path' => $filenameWithoutExtension, 'extension' => $extension]
    );
});
```

I had to relocate the handling of the notifications to the new class `FiamentExport` and while there i split the handling of the notification methods for easier maintenance going forward.

Let me know your thoughts about this.

P.S: This also updates the readme :)

Thank you!:)