### PR TITLE
check if filename has extension

### DIFF
--- a/src/Exports/Concerns/WithFilename.php
+++ b/src/Exports/Concerns/WithFilename.php
@@ -27,7 +27,7 @@ trait WithFilename
 
     protected function ensureFilenameHasExtension(string $filename): string
     {
-        return Str::contains($filename, '.')
+        return Str::of($filename)->test('/\.\w{3,4}$/')
             ? $filename
             : $filename.'.'.$this->getDefaultExtension();
     }


### PR DESCRIPTION
Fix for bug https://github.com/pxlrbt/filament-excel/issues/95

Checks if filename ends with dot and 3-4 characters. (note: using 3-4 as this matches the intended use case: csv, xlsx)