### PR TITLE
feat(model): Added modifyModelUsing to use custom model

### DIFF
--- a/src/Exports/Concerns/CanModifyModel.php
+++ b/src/Exports/Concerns/CanModifyModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace pxlrbt\FilamentExcel\Exports\Concerns;
+
+use Closure;
+use Laravel\SerializableClosure\SerializableClosure;
+
+trait CanModifyModel
+{
+  public ?SerializableClosure $modifyModelUsing = null;
+
+  public function modifyModelUsing(string|Closure $model): static
+  {
+    $this->model = $model;
+
+    return $this;
+  }
+}

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -24,6 +24,7 @@ use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Events\BeforeSheet;
 use pxlrbt\FilamentExcel\Events\ExportFinishedEvent;
 use pxlrbt\FilamentExcel\Exports\Concerns\CanIgnoreFormatting;
+use pxlrbt\FilamentExcel\Exports\Concerns\CanModifyModel;
 use pxlrbt\FilamentExcel\Exports\Concerns\CanModifyQuery;
 use pxlrbt\FilamentExcel\Exports\Concerns\CanQueue;
 use pxlrbt\FilamentExcel\Exports\Concerns\Except;
@@ -45,6 +46,7 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
     use AskForFilename;
     use AskForWriterType;
     use CanIgnoreFormatting;
+    use CanModifyModel;
     use CanModifyQuery;
     use CanQueue, Exportable  {
         Exportable::download as downloadExport;


### PR DESCRIPTION
Based on what I need, I need/want to use this Exporter on my custom Livewire Page and I don't want to use table there. Before, I extends ExcelExport Class and override it to enabled me to use custom model that I can specify.