### PR TITLE
Fixes "Export fails with TextColumn::make()->numeric() in Filament v4 (The column [x] is not mounted to a table)"

### DIFF
--- a/src/Columns/Column.php
+++ b/src/Columns/Column.php
@@ -100,7 +100,6 @@ class Column
 
         // Reset other properties
         $clone->layout(null);
-        $clone->table(null);
         $clone->getStateUsing(null);
         invade($clone)->summarizers = [];
 


### PR DESCRIPTION
Fixes the problem in the issue #234 by removing the `$clone->table(null)` that causes the error mentioned.