### PR TITLE
Fixed export from manageRelatedRecords tables

### DIFF
--- a/src/Actions/ExportAction.php
+++ b/src/Actions/ExportAction.php
@@ -3,6 +3,7 @@
 namespace pxlrbt\FilamentExcel\Actions;
 
 use Filament\Actions\Action;
+use Filament\Resources\Pages\ManageRelatedRecords;
 use pxlrbt\FilamentExcel\Actions\Concerns\ExportableAction;
 use pxlrbt\FilamentExcel\Exports\ExcelExport;
 
@@ -36,7 +37,7 @@ class ExportAction extends Action
 
         return app()->call([$exportable, 'hydrate'], [
             'livewire' => $this->getLivewire(),
-            'records' => property_exists($livewire, 'record') ? collect([$livewire->record]) : null,
+            'records' => (property_exists($livewire, 'record') && ! $livewire instanceof ManageRelatedRecords) ? collect([$livewire->record]) : null,
             'formData' => data_get($data, $exportable->getName()),
         ])->export();
     }

--- a/src/Exports/ExcelExport.php
+++ b/src/Exports/ExcelExport.php
@@ -5,6 +5,7 @@ namespace pxlrbt\FilamentExcel\Exports;
 use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Database\Eloquent\Model;
@@ -158,6 +159,8 @@ class ExcelExport implements FromQuery, HasHeadings, HasMapping, ShouldAutoSize,
         if ($this->livewire instanceof RelationManager) {
             $this->livewire->pageClass = $this->livewireClass;
             $this->livewire->ownerRecord = $this->livewireOwnerRecord;
+        } elseif ($this->livewire instanceof ManageRelatedRecords && $this->livewireOwnerRecord) {
+            $this->livewire->record = $this->livewireOwnerRecord;
         }
 
         if ($this->isQueued) {


### PR DESCRIPTION
Fix bug where exports from the ManagedRelatedRecord stayed empty.

Now the query in `ExcelExport.php`  on line 310 gets the correct data from Table.
