### PR TITLE
feat: add `withoutGeneratedColumns()` to exclude auto-generated columns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,8 @@ Available settings: `delimiter`, `enclosure`, `lineEnding`, `useBom`, `includeSe
 
 When using `->fromForm()`/`->fromTable()`/`->fromModel()` the columns are resolved from your table or form definition. You can also provide columns manually, append columns or overwrite generated columns.
 
+If you want to fully control which columns are exported and ignore all auto-generated columns, you can use `->withoutGeneratedColumns()`:
+
 ```php
 use pxlrbt\FilamentExcel\Actions\Tables\ExportAction;
 use pxlrbt\FilamentExcel\Exports\ExcelExport;

--- a/src/Exports/Concerns/WithColumns.php
+++ b/src/Exports/Concerns/WithColumns.php
@@ -23,6 +23,8 @@ trait WithColumns
 
     public Closure|array $generatedColumns = [];
 
+    protected bool $withoueGeneratedColumns = false;
+
     protected ?Collection $cachedMap = null;
 
     protected ?string $columnsSource = null;
@@ -42,9 +44,18 @@ trait WithColumns
         return $this;
     }
 
+    public function withoutGeneratedColumns(Closure|bool $condition = true): static
+    {
+        $this->withoueGeneratedColumns = $condition;
+
+        return $this;
+    }
+
     public function getColumns(): array
     {
-        $columns = $this->evaluate($this->generatedColumns);
+        $columns = ! $this->evaluate($this->withoueGeneratedColumns)
+            ? $this->evaluate($this->generatedColumns)
+            : [];
 
         foreach ($this->evaluate($this->columns) as $column) {
             if ($this->columnsSource === 'table' && array_key_exists($column->getName(), $columns)) {


### PR DESCRIPTION
## Summary

This PR introduces a new method `withoutGeneratedColumns()` to the `WithColumns` concern. It allows developers to explicitly disable automatically generated columns when exporting data.

## Motivation

Currently, when using `->fromTable()` or similar helpers, columns may be auto-generated based on the table definition or model attributes. While methods like `->only()` and `->except()` exist, they still operate on the final resolved column set, which may include implicitly generated columns.

There is no straightforward way to completely opt out of generated columns and rely solely on manually defined columns via `->withColumns()` .

This leads to:

- Unexpected extra columns in exports
- Additional filtering logic using `except([])` or `only([])`
- Reduced clarity in intent